### PR TITLE
🌿 최상위 Android build.gradle(project) 변경 🌿

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ android {
 
 repositories {
   maven {
-      url "https://github.com/doofgret/maven-repository/raw/master/releases"
+      url "https://github.com/narvis2/video-meeting-webrtc-maven-repository/raw/main/releases"
   }
   google()
   mavenCentral()
@@ -45,7 +45,7 @@ repositories {
 }
 
 dependencies {
-    implementation ('org.jitsi.react:jitsi-meet-sdk:0.0.1') {
+    implementation ('org.jitsi.react:jitsi-meet-sdk:1.1.0') {
       transitive = true
     }
 }


### PR DESCRIPTION
## 🍀 android > build.gradle(project) 변경
- `maven url`
  - 기존 👉 url "https://github.com/doofgret/maven-repository/raw/master/releases"
  - 변경 👉 url "https://github.com/narvis2/video-meeting-webrtc-maven-repository/raw/main/releases"
- `dependencies`
  - 기존 👉 org.jitsi.react:jitsi-meet-sdk:0.0.1
  - 변경 👉 org.jitsi.react:jitsi-meet-sdk:1.1.0